### PR TITLE
21_twitterに投稿するボタン配置

### DIFF
--- a/rarestudy/templates/article/detail.html
+++ b/rarestudy/templates/article/detail.html
@@ -17,6 +17,7 @@
                     <p class="small text-secondary">{{ Article.get_created_at }}</p>
                 </div>
                 <p>{{ Article.get_body | markdown | safe }}</p>
+                <a href="https://twitter.com/share" class="twitter-share-button" data-text="RareStudyにて新しいアウトプットが投稿されました。" data-lang="ja" data-count="none" data-hashtags="RareTECH,RareStudy">Tweet Button</a>
             </div>
             <div class="col-lg-10 mx-auto">
                 {% if Article.get_comments %}

--- a/rarestudy/templates/base.html
+++ b/rarestudy/templates/base.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.15.6/styles/a11y-dark.min.css">
     <link href="https://use.fontawesome.com/releases/v5.6.1/css/all.css" rel="stylesheet">
     <link href="{% static "css/custom.css" %}" rel="stylesheet" />
+    <script>!function(d,s,id){var js,fjs=d.getElementsByTagName(s)[0];if(!d.getElementById(id)){js=d.createElement(s);js.id=id;js.src="https://platform.twitter.com/widgets.js";fjs.parentNode.insertBefore(js,fjs);}}(document,"script","twitter-wjs");</script>
     <title>RareStudy</title>
     <style>
         .header{


### PR DESCRIPTION
[trello](https://trello.com/c/wnl29vXk)

## やったこと
- twitterの投稿画面に遷移し、ある程度入力が終わったページを表示するボタンを配置